### PR TITLE
Allow command line opening of a file as arg

### DIFF
--- a/src/ssNake.py
+++ b/src/ssNake.py
@@ -8131,6 +8131,8 @@ if __name__ == '__main__':
     if not quit:
         mainProgram = MainProgram(root)
         mainProgram.setWindowTitle("ssNake - " + VERSION)
+        if len(sys.argv) > 1:
+            mainProgram.loadData([sys.argv[1]])
         mainProgram.show()
         if not error:
             splash.finish(mainProgram)


### PR DESCRIPTION
This commit use the first argument as the data to open when launch from command line.
Further improvement could be to implement batch processing through command line with advanced argument parsing (using argparse).