### PR TITLE
Adds peak Cq values and average Pq values to the Czjzek Distribution Plot

### DIFF
--- a/src/fitting.py
+++ b/src/fitting.py
@@ -3895,8 +3895,18 @@ class CzjzekPrefWindow(QtWidgets.QWidget):
             self.czjzek = Czjzek.czjzekIntensities(sigma, d, cq.flatten(), eta.flatten())
         else:
             self.czjzek = Czjzek.czjzekIntensities(sigma, d, cq.flatten(), eta.flatten(), cq0, eta0)
+
         self.czjzek = self.czjzek.reshape(etasteps, cqsteps)
-        self.ax.contour(cq.transpose(), eta.transpose(), self.czjzek.transpose(), 10)
+        # Calculate peak CQ values (DMFit Approach) or average SOQE values
+        cgCQs = cq[0, np.argmax(self.czjzek, axis=1)]
+        cgSOQES = cgCQs[1:] * np.sqrt(1 + eta[1:,0]/3)
+
+        indices = np.where(self.czjzek == np.max(self.czjzek))
+        peakCQ = float(cq[indices[0], indices[1]])
+        avgSOQE = np.average(cgSOQES)
+        self.ax.contour(cq.transpose(), eta.transpose(), self.czjzek.transpose(), 15)
+        self.ax.text(0, 1.05, '$\overline{P_Q}$ = ' + str(np.round(avgSOQE, decimals=3)) 
+            + ' MHz' + '   -   $C_{Q,peak}$ = ' + str(np.round(peakCQ, decimals=3)) + ' MHz')
         self.ax.set_xlabel(u"C$_Q$ [MHz]")
         self.ax.set_ylabel(u"η")
         self.canvas.draw()


### PR DESCRIPTION
While the sigma parameter is probably the most straightforward way to describe a Czjzek distribution, many authors use to report the "peak" CQ value of a Czjzek distribution, as obtained from, e.g., the Cz_simple model implemented in DMFit (see also https://nmr.cemhti.cnrs-orleans.fr/Dmfit/Howto/Glass/Default.aspx).

This commit conveniently calculates and displays the peak CQ value in the Czjzek distribution window of ssNake to allow for backwards comparability. Below see an exemplary Czjzek distribution where the peak CQ value is indicated by a vertical line.

![image](https://user-images.githubusercontent.com/67208403/168484634-424f2eca-662c-4521-8d9b-9cedec8ab7e5.png)

Moreover, it displays the average PQ (SOQE) value, obtained from the center of mass of the Czjzek distribution in a PQ vs. eta plot, which is not skewed, and thus in my modest opinion, more representative and easier to compare for example with PQ values obtained from MQMAS experiments. In the example below you can see the average PQ value indicated in the same Czjzek distribution in a PQ vs eta plot.

![image](https://user-images.githubusercontent.com/67208403/168484584-743823fd-205d-4558-b060-d369b944da50.png)

The overall result looks like this:

![image](https://user-images.githubusercontent.com/67208403/168483918-b876476a-fa4d-4ec3-86af-f55fd565a51a.png)

PS: I increased the number of contour lines of the Czjzek distribution plot to 15 - this is, of course, personal preference and may be disregarded.