### PR TITLE
Prevent saving as invalid matlab variable name

### DIFF
--- a/src/specIO.py
+++ b/src/specIO.py
@@ -844,7 +844,7 @@ def saveMatlabFile(filePath, spectrum, name='spectrum'):
     if spectrum.dFilter is not None:
         struct['dFilter'] = spectrum.dFilter
     if not re.match(r'^[a-z]\w+$', name, re.IGNORECASE):
-        # Matlab name must start with a letter, then any of letters, digits or underscores
+        # Matlab variable name must start with a letter, then any of letters, digits or underscores
         name = 'nmr_' + re.sub('\W', '_', name)
     matlabStruct = {name: struct}
     scipy.io.savemat(filePath, matlabStruct)

--- a/src/specIO.py
+++ b/src/specIO.py
@@ -843,6 +843,9 @@ def saveMatlabFile(filePath, spectrum, name='spectrum'):
     struct['metaData'] = spectrum.metaData
     if spectrum.dFilter is not None:
         struct['dFilter'] = spectrum.dFilter
+    if not re.match(r'^[a-z]\w+$', name, re.IGNORECASE):
+        # Matlab name must start with a letter, then any of letters, digits or underscores
+        name = 'nmr_' + re.sub('\W', '_', name)
     matlabStruct = {name: struct}
     scipy.io.savemat(filePath, matlabStruct)
 


### PR DESCRIPTION
Matlab variable names must start with a letter, then either of letters, numbers or `_` (https://www.mathworks.com/help/matlab/matlab_prog/variable-names.html) If the spectrum name doesn't satisfy this (e.g. a spectrum called "01_mysample_1H_echo"), convert it to something that can actually be read by Matlab. (Prefixing `nmr_` to ensure the start with a letter, and replacing all invalid chars by `_`)

Technically, it should also ensure the spectrum name isn't something like `if`, `for`, `end`, ..., but let's ignore that for now as the likelyhood of that is small