### PR TITLE
Inserting workspace with incorrect dimensions causes error and badly modified data

### DIFF
--- a/src/spectrum.py
+++ b/src/spectrum.py
@@ -367,6 +367,11 @@ class Spectrum(object):
         axis : int, optional
             The dimension along which to add the data.
             By default the last dimension is used.
+
+        Raises
+        ------
+        SpectrumException
+            When the inserted spectrum has insufficient dimensions
         """
         if not isinstance(data, hc.HComplexData):
             data = hc.HComplexData(data)
@@ -380,6 +385,8 @@ class Spectrum(object):
                 returnValue = lambda self: self.restoreData(copyData, lambda self: self.insert(data, pos, axis))
         axis = self.checkAxis(axis)
         # Check for a change in dimensions
+        if len(data.shape()) <= axis:
+            raise SpectrumException("Data does not have the correct number of dimensions")
         self.data = self.data.insert(pos, data, axis)
         self.resetXax(axis)
         self.addHistory("Inserted " + str(data.shape()[axis]) + " datapoints in dimension " + str(axis + 1) + " at position " + str(pos))


### PR DESCRIPTION

1. Have spectrum A of size 15000x12 and  spectrum B of size 15000x1 (or any size, as long as A is a NxM matrix and B an Nx1 matrix; N,M>1)
2. On spectrum A, use `Combine` -> `Combine Workspaces`. Select spectrum B

The following error is shown. Note that, despite the error being shown and the appearance nothing happened, the data is modified (badly).

```
Traceback (most recent call last): 
File "widgetClasses.py", line 407, in applyAndClose self.applyFunc() 
File "ssNake.py", line 5163, in applyFunc self.father.current.insert(self.father.father.workspaces[ws].masterData.getData(), pos) 
File "views.py", line 1772, in insert self.data.insert(data, pos, self.axes[-1]) 
File "spectrum.py", line 382, in insert self.addHistory("Inserted " + str(data.shape()[axis]) + " datapoints in dimension " + str(axis + 1) + " at position " + str(pos)) 
IndexError: tuple index out of range 
```

This PR throws a (human-understandable) error and prevents data from being modified if the dimensions are incorrect. 