### PR TITLE
Show full name in tooltip if shortened

### DIFF
--- a/src/ssNake.py
+++ b/src/ssNake.py
@@ -2454,8 +2454,11 @@ class SideFrame(QtWidgets.QScrollArea):
                 frameWidget.setLayout(frame)
                 name = current.viewSettings["extraName"][i]
                 if len(name) > 20:
-                    name = name[:20]
-                self.nameLabels.append(wc.QLabel(name, self))
+                    nameLabel = wc.QLabel(name[:20] + '…', self)
+                    nameLabel.setToolTip(name)
+                else:
+                    nameLabel = wc.QLabel(name, self)
+                self.nameLabels.append(nameLabel)
                 frame.addWidget(self.nameLabels[i], 0, 0, 1, 3)
                 self.nameLabels[i].setStyleSheet("QLabel { color: rgb" + str(current.getExtraColor(i)) + ";}")
                 colorbutton = QtWidgets.QPushButton("Colour", self)


### PR DESCRIPTION
If you have two names which are identical in the first 20 characters, you will not be able to distinguish (for example) the following two names in Multiplot mode:
`H1_600_specialsample_beforeheating`
`H1_600_specialsample_afterheating`

This PR adds the full name as a tooltip of the shortened name, so that by hovering your mouse you can still observe which spectrum corresponds to which name
![image](https://user-images.githubusercontent.com/1315520/219713612-b893ec2f-b84e-4205-a79a-c868d33baa84.png)
