### PR TITLE
Output the fitting parameters for the baseline

### DIFF
--- a/src/spectrum.py
+++ b/src/spectrum.py
@@ -691,7 +691,7 @@ class Spectrum(object):
         if not self.noUndo:
             self.undoList.append(lambda self: self.normalize(1.0 / mult, scale, type, axis, select=select))
 
-    def baselineCorrection(self, baseline, axis=-1, select=slice(None)):
+    def baselineCorrection(self, baseline, axis=-1, select=slice(None), degree=None, type=None):
         """
         Applies a baseline correction.
 
@@ -706,6 +706,10 @@ class Spectrum(object):
         select : Slice, optional
             An optional selection of the spectrum data on which the baseline correction is performed.
             By default the entire data is used.
+        degree : int, optional
+            The degree used for the fitting of the baseline, used for history output only.
+        type : str, optional
+            The type (poly or sin/cos) used for the fitting, used for history output only.
         """
         axis = self.checkAxis(axis)
         baselinetmp = baseline.reshape((self.shape()[axis], ) + (1, ) * (self.ndim() - axis - 1))
@@ -715,6 +719,8 @@ class Spectrum(object):
             Message = Message + " with slice " + str(select)
         elif select != slice(None, None, None):
             Message = Message + " with slice " + str(select)
+        if degree and type:
+            Message = Message + " ({type}, deg={deg})".format(type=type, deg=str(degree))
         self.addHistory(Message)
         self.redoList = []
         if not self.noUndo:

--- a/src/views.py
+++ b/src/views.py
@@ -1441,7 +1441,7 @@ class Current1D(PlotFrame):
         y = self.baselineFunctionFit(self.xax(), tmpData, bArray, degree, type)
         y = np.real(self.getDataType(y))
         self.root.addMacro(['baselineCorrection', (y, self.axes[-1] - self.data.ndim(), selectSlice)])
-        self.data.baselineCorrection(y, self.axes[-1], select=selectSlice)
+        self.data.baselineCorrection(y, self.axes[-1], select=selectSlice, degree=degree, type=type)
 
     def previewBaselineCorrection(self, degree, removeList, type, invert=False):
         """


### PR DESCRIPTION
The history output doesn't show the fitting parameters for baseline correction. Hence, using the textual history, it is impossible to later find out which correction method was used. This PR adds this functionality. Example output would be:
```
Baseline corrected dimension 2 (poly, deg=9)
Baseline corrected dimension 2 (sin/cos, deg=9)
```