### PR TITLE
Phasing: Add second order phasing

### DIFF
--- a/DocSrc/ReferenceManual.tex
+++ b/DocSrc/ReferenceManual.tex
@@ -492,6 +492,9 @@ Change the default settings of a contour plot.
   \item Ratio: sets the default ratio of the contour plot.
 \end{itemize}
 
+\subsubsection{Phasing}
+Decide if the second order phase correction should be displayed in the phasing dialog. This is only necessary if spectra with frequency swept pulses are to be phased and should generally be disabled unless necessary.
+
 \subsection{Quit}
 Closes the ssNake application. Quiting ssNake always asks for confirmation, to prevent data loss.
 
@@ -713,21 +716,21 @@ For most apodization types, negative line broadening parameters are allowed, but
 
 
 \subsection{Phasing}
-Opens a tool that can be use to change the phasing in the current spectrum or fid. Supports zero order and first order phasing. It also provides buttons for autophasing.
+Opens a tool that can be use to change the phasing in the current spectrum or fid. Supports zero order, first order and second order phasing. The option for second order phasing is hidden by default, but can be activated in the general preferences. It also provides buttons for autophasing.
 
-Selecting phasing in the tools menu opens the phasing window. In this windows, the zero and first
-order phasing can be set, as well as the pivot point (centre point) for the first order phasing. The
-values can be either filled in the boxes,  changed by pushing the left and right buttons (click for
-$\pm1$, ctrl+click for $\pm10$, shift+click for $\pm100$, and shift+ctrl+click for $\pm1000$) , or set by dragging the slider to the
-left or the right. For zero order phase correction, the limits are -180 and 180 degrees. For first
-order correction, these are -540 and 540 degrees. Higher values for the first order correction
-sometimes make sense, and can be filled in the box directly, or via clicking on the arrows. Note
-that the values for the zero order correction are circular, so that -180 and 180 degrees lead to the
-same effect.
+Selecting phasing in the tools menu opens the phasing window. In this windows, the zero, first and second order phasing can be set, as well as the pivot point (centre point) for the first and second order phasing. The
+values can be either filled in the boxes, changed by pushing the left and right buttons (click for
+$\pm1$, ctrl+click for $\pm10$, shift+click for $\pm100$, and shift+ctrl+click for $\pm1000$) , or set
+by dragging the slider to the left or the right. For zero order phase correction, the limits are -180
+and 180 degrees. For first order correction, these are -540 and 540 degrees. For second order
+correction, the limits are -1440 and 1440 degrees. Higher values for the first and second order
+corrections sometimes make sense, and can be filled in the box directly, or via clicking on the
+arrows. Note that the values for the zero order correction are circular, so that -180 and 180 degrees
+lead to the same effect.
 
 While in this menu, the effect of a certain phasing can be immediately viewed in the ssNake window.
 When a good setting is reached, `Ok' can be pushed to apply the phasing. Note that for
-multidimensional data, the preview only shows the current trace. Pushing `Ok' the applies the same
+multidimensional data, the preview only shows the current trace. Pushing `Ok' then applies the same
 phasing correction on all the traces (might take some time for large data). If the phasing should
 only be applied on the current spectrum or fid, the box `Single slice' can be ticked. Note that you
 still have to push `Ok' to apply the phasing.

--- a/DocSrc/ReferenceManual.tex
+++ b/DocSrc/ReferenceManual.tex
@@ -493,7 +493,7 @@ Change the default settings of a contour plot.
 \end{itemize}
 
 \subsubsection{Phasing}
-Decide if the second order phase correction should be displayed in the phasing dialog. This is only necessary if spectra with frequency swept pulses are to be phased and should generally be disabled unless necessary.
+Decide if the second order phase correction should be displayed by default in the phasing dialog. This is only necessary if spectra with frequency swept pulses are to be phased and should generally be disabled unless necessary.
 
 \subsection{Quit}
 Closes the ssNake application. Quiting ssNake always asks for confirmation, to prevent data loss.
@@ -716,10 +716,11 @@ For most apodization types, negative line broadening parameters are allowed, but
 
 
 \subsection{Phasing}
-Opens a tool that can be use to change the phasing in the current spectrum or fid. Supports zero order, first order and second order phasing. The option for second order phasing is hidden by default, but can be activated in the general preferences. It also provides buttons for autophasing.
+Opens a tool that can be use to change the phasing in the current spectrum or fid. Supports zero order, first order and second order phasing. The option for second order phasing is hidden by default, but can be activated by checking the check box at the bottom of the window. This option can also be set permanently in the general preferences. It also provides buttons for autophasing.
 
-Selecting phasing in the tools menu opens the phasing window. In this windows, the zero, first and second order phasing can be set, as well as the pivot point (centre point) for the first and second order phasing. The
-values can be either filled in the boxes, changed by pushing the left and right buttons (click for
+Selecting phasing in the tools menu opens the phasing window. In this windows, the zero, first and second order phasing can be set, as well as the pivot points (centre points) for the first and second order phasing.
+While the pivot point for the second order correction only influences the second order phasing, the pivot point of the first order correction influences both the first and second order correction.
+The values can be either filled in the boxes, changed by pushing the left and right buttons (click for
 $\pm1$, ctrl+click for $\pm10$, shift+click for $\pm100$, and shift+ctrl+click for $\pm1000$) , or set
 by dragging the slider to the left or the right. For zero order phase correction, the limits are -180
 and 180 degrees. For first order correction, these are -540 and 540 degrees. For second order

--- a/src/ssNake.py
+++ b/src/ssNake.py
@@ -3659,17 +3659,19 @@ class PhaseWindow(wc.ToolWindow):
             raise SsnakeException('Phasing: first order value input is not valid!')
         value += phase1 * self.PHASE1STEP
         if self.father.current.spec() > 0:
-            self.inputRef()
+            self.inputRef(1)
         second = safeEval(self.secondEntry.text(), length=self.father.current.len(), Type='FI')
         if second is None:
             raise SsnakeException('Phasing: second order value input is not valid!')
         second += phase2 * self.PHASE2STEP
+        if self.father.current.spec() > 0:
+            self.inputRef(2)
         pivot1 = self.pivotFirstVal / self.father.current.sw()
         pivot2 = self.pivotSecondVal / self.father.current.sw()
         if pivot1 == pivot2:
-            newFirst = (self.firstVal - 2 * (value - self.secondVal) * pivot1)
+            newFirst = (value - 2 * (second - self.secondVal) * pivot1)
         else:
-            newFirst = (self.firstVal + (value - self.secondVal) * (np.power(pivot2, 2) - np.power(pivot1, 2)) / (pivot1 - pivot2))
+            newFirst = (value + (second - self.secondVal) * (np.power(pivot2, 2) - np.power(pivot1, 2)) / (pivot1 - pivot2))
         newZero = (self.zeroVal - (newFirst - self.firstVal) * pivot1 - (second - self.secondVal) * np.power(pivot1, 2))
         self.zeroVal = np.mod(newZero + 180, 360) - 180
         self.zeroEntry.setText('%.3f' % self.zeroVal)

--- a/src/ssNake.py
+++ b/src/ssNake.py
@@ -248,6 +248,7 @@ class MainProgram(QtWidgets.QMainWindow):
         self.defaultContourConst = True
         self.defaultPosColor = '#1F77B4'
         self.defaultNegColor = '#FF7F0E'
+        self.defaultSecondOrderPhaseDialog = False
         self.defaultStartupBool = False
         self.defaultStartupDir = '~'
         self.defaultTooltips = True
@@ -352,6 +353,7 @@ class MainProgram(QtWidgets.QMainWindow):
             self.defaultHeightRatio = settings.value("contour/height_ratio", self.defaultHeightRatio, float)
         except TypeError:
             self.dispMsg("Incorrect value in the config file for the contour/height_ratio")
+        self.defaultSecondOrderPhaseDialog = settings.value("phasing/second_order_phase_dialog", self.defaultSecondOrderPhaseDialog, bool)
 
     def saveDefaults(self):
         QtCore.QSettings.setDefaultFormat(QtCore.QSettings.IniFormat)
@@ -389,6 +391,7 @@ class MainProgram(QtWidgets.QMainWindow):
         settings.setValue("contour/diagonalbool", self.defaultDiagonalBool)
         settings.setValue("contour/diagonalmult", self.defaultDiagonalMult)
         settings.setValue("2Dcolor/colourmap", self.defaultPColorMap)
+        settings.setValue("phasing/second_order_phase_dialog", self.defaultSecondOrderPhaseDialog)
 
     def dispMsg(self, msg, color='black'):
         if color == 'red':
@@ -3477,6 +3480,7 @@ class PhaseWindow(wc.ToolWindow):
         self.secondOrderFrame.addWidget(self.secondScale, 3, 0, 1, 3)
         self.secondOrderGroup.setLayout(self.secondOrderFrame)
         self.grid.addWidget(self.secondOrderGroup, 2, 0, 1, 3)
+        self.secondOrderGroup.setVisible(self.father.father.defaultSecondOrderPhaseDialog)
 
     def setModifierTexts(self, event):
         sign = u"\u00D7"
@@ -6939,18 +6943,22 @@ class PreferenceWindow(QtWidgets.QWidget):
         tab2 = QtWidgets.QWidget()
         tab3 = QtWidgets.QWidget()
         tab4 = QtWidgets.QWidget()
+        tab5 = QtWidgets.QWidget()
         tabWidget.addTab(tab1, "Window")
         tabWidget.addTab(tab2, "Plot")
         tabWidget.addTab(tab3, "Contour")
         tabWidget.addTab(tab4, "2D Colour")
+        tabWidget.addTab(tab5, "Phasing")
         grid1 = QtWidgets.QGridLayout()
         grid2 = QtWidgets.QGridLayout()
         grid3 = QtWidgets.QGridLayout()
         grid4 = QtWidgets.QGridLayout()
+        grid5 = QtWidgets.QGridLayout()
         tab1.setLayout(grid1)
         tab2.setLayout(grid2)
         tab3.setLayout(grid3)
         tab4.setLayout(grid4)
+        tab5.setLayout(grid5)
         grid1.setColumnStretch(10, 1)
         grid1.setRowStretch(10, 1)
         grid2.setColumnStretch(10, 1)
@@ -6959,6 +6967,8 @@ class PreferenceWindow(QtWidgets.QWidget):
         grid3.setRowStretch(10, 1)
         grid4.setColumnStretch(10, 1)
         grid4.setRowStretch(10, 1)
+        grid5.setColumnStretch(10, 1)
+        grid5.setRowStretch(10, 1)
         # grid1.addWidget(wc.QLabel("Window size:"), 0, 0, 1, 2)
         grid1.addWidget(wc.QLabel("Width:"), 1, 0)
         self.widthSpinBox = wc.SsnakeSpinBox()
@@ -7092,6 +7102,10 @@ class PreferenceWindow(QtWidgets.QWidget):
         self.cmEntry2D.addItems(views.COLORMAPLIST)
         self.cmEntry2D.setCurrentIndex(views.COLORMAPLIST.index(self.father.defaultPColorMap))
         grid4.addWidget(self.cmEntry2D, 0, 1)
+        # Phasing Options (if 2nd order should be available)
+        self.secondOrderPhaseCheckBox = QtWidgets.QCheckBox("Show 2nd order phase correction")
+        self.secondOrderPhaseCheckBox.setChecked(self.father.defaultSecondOrderPhaseDialog)
+        grid5.addWidget(self.secondOrderPhaseCheckBox, 0, 1)
         # Others
         layout = QtWidgets.QGridLayout(self)
         layout.addWidget(tabWidget, 0, 0, 1, 4)
@@ -7159,6 +7173,7 @@ class PreferenceWindow(QtWidgets.QWidget):
         self.father.defaultWidthRatio = self.WRSpinBox.value()
         self.father.defaultHeightRatio = self.HRSpinBox.value()
         self.father.defaultPColorMap = self.cmEntry2D.currentText()
+        self.father.defaultSecondOrderPhaseDialog = self.secondOrderPhaseCheckBox.isChecked()
         self.father.saveDefaults()
         self.closeEvent()
 

--- a/src/ssNake.py
+++ b/src/ssNake.py
@@ -3395,13 +3395,16 @@ class PhaseWindow(wc.ToolWindow):
     SINGLESLICE = True
     RESOLUTION = 1000
     P1LIMIT = 540.0
+    P2LIMIT = 1440.0
     PHASE0STEP = 1.0
     PHASE1STEP = 1.0
+    PHASE2STEP = 1.0
 
     def __init__(self, parent):
         super(PhaseWindow, self).__init__(parent)
         self.zeroVal = 0.0
         self.firstVal = 0.0
+        self.secondVal = 0.0
         self.pivotVal = 0.0
         self.available = True
         # Zero order
@@ -3413,11 +3416,11 @@ class PhaseWindow(wc.ToolWindow):
         self.zeroEntry = wc.QLineEdit("0.000", self.inputZeroOrder)
         self.zeroOrderFrame.addWidget(self.zeroEntry, 2, 1)
         self.leftZero = QtWidgets.QPushButton("<")
-        self.leftZero.clicked.connect(lambda: self.stepPhase(-1, 0))
+        self.leftZero.clicked.connect(lambda: self.stepPhase(-1, 0, 0))
         self.leftZero.setAutoRepeat(True)
         self.zeroOrderFrame.addWidget(self.leftZero, 2, 0)
         self.rightZero = QtWidgets.QPushButton(">")
-        self.rightZero.clicked.connect(lambda: self.stepPhase(1, 0))
+        self.rightZero.clicked.connect(lambda: self.stepPhase(1, 0, 0))
         self.rightZero.setAutoRepeat(True)
         self.zeroOrderFrame.addWidget(self.rightZero, 2, 2)
         self.zeroScale = wc.SsnakeSlider(QtCore.Qt.Horizontal)
@@ -3435,11 +3438,11 @@ class PhaseWindow(wc.ToolWindow):
         self.firstEntry = wc.QLineEdit("0.000", self.inputFirstOrder)
         self.firstOrderFrame.addWidget(self.firstEntry, 6, 1)
         self.leftFirst = QtWidgets.QPushButton("<")
-        self.leftFirst.clicked.connect(lambda: self.stepPhase(0, -1))
+        self.leftFirst.clicked.connect(lambda: self.stepPhase(0, -1, 0))
         self.leftFirst.setAutoRepeat(True)
         self.firstOrderFrame.addWidget(self.leftFirst, 6, 0)
         self.rightFirst = QtWidgets.QPushButton(">")
-        self.rightFirst.clicked.connect(lambda: self.stepPhase(0, 1))
+        self.rightFirst.clicked.connect(lambda: self.stepPhase(0, 1, 0))
         self.rightFirst.setAutoRepeat(True)
         self.firstOrderFrame.addWidget(self.rightFirst, 6, 2)
         self.firstScale = wc.SsnakeSlider(QtCore.Qt.Horizontal)
@@ -3455,13 +3458,32 @@ class PhaseWindow(wc.ToolWindow):
             self.firstOrderFrame.addWidget(self.refEntry, 10, 1)
         self.firstOrderGroup.setLayout(self.firstOrderFrame)
         self.grid.addWidget(self.firstOrderGroup, 1, 0, 1, 3)
+        # Second order
+        self.secondOrderGroup = QtWidgets.QGroupBox('Second order:')
+        self.secondOrderFrame = QtWidgets.QGridLayout()
+        self.secondEntry = wc.QLineEdit("0.000", self.inputSecondOrder)
+        self.secondOrderFrame.addWidget(self.secondEntry, 0, 1)
+        self.leftSecond = QtWidgets.QPushButton("<")
+        self.leftSecond.clicked.connect(lambda: self.stepPhase(0, 0, -1))
+        self.leftSecond.setAutoRepeat(True)
+        self.secondOrderFrame.addWidget(self.leftSecond, 2, 0)
+        self.rightSecond = QtWidgets.QPushButton(">")
+        self.rightSecond.clicked.connect(lambda: self.stepPhase(0, 0, 1))
+        self.rightSecond.setAutoRepeat(True)
+        self.secondOrderFrame.addWidget(self.rightSecond, 2, 2)
+        self.secondScale = wc.SsnakeSlider(QtCore.Qt.Horizontal)
+        self.secondScale.setRange(-self.RESOLUTION, self.RESOLUTION)
+        self.secondScale.valueChanged.connect(self.setSecondOrder)
+        self.secondOrderFrame.addWidget(self.secondScale, 3, 0, 1, 3)
+        self.secondOrderGroup.setLayout(self.secondOrderFrame)
+        self.grid.addWidget(self.secondOrderGroup, 2, 0, 1, 3)
 
     def setModifierTexts(self, event):
         sign = u"\u00D7"
         if event.modifiers() & QtCore.Qt.AltModifier:
             sign = '/'
-        left = [self.leftZero, self.leftFirst]
-        right = [self.rightZero, self.rightFirst]
+        left = [self.leftZero, self.leftFirst, self.leftSecond]
+        right = [self.rightZero, self.rightFirst, self.rightSecond]
         if event.modifiers() & QtCore.Qt.ControlModifier and event.modifiers() & QtCore.Qt.ShiftModifier:
             text = ' ' + sign + '1000'
         elif event.modifiers() & QtCore.Qt.ControlModifier:
@@ -3485,7 +3507,7 @@ class PhaseWindow(wc.ToolWindow):
         if self.available:
             self.zeroVal = float(value) / self.RESOLUTION * 180
             self.zeroEntry.setText('%.3f' % self.zeroVal)
-            self.father.current.setPhaseInter(np.pi * self.zeroVal / 180.0, np.pi * self.firstVal / 180.0)
+            self.father.current.setPhaseInter(np.pi * self.zeroVal / 180.0, np.pi * self.firstVal / 180.0, np.pi * self.secondVal / 180.0)
 
     def inputZeroOrder(self, *args):
         inp = safeEval(self.zeroEntry.text(), length=self.father.current.len(), Type='FI')
@@ -3496,7 +3518,7 @@ class PhaseWindow(wc.ToolWindow):
         self.available = False
         self.zeroScale.setValue(int(round(self.zeroVal / 180.0 * self.RESOLUTION)))
         self.available = True
-        self.father.current.setPhaseInter(np.pi * self.zeroVal / 180.0, np.pi * self.firstVal / 180.0)
+        self.father.current.setPhaseInter(np.pi * self.zeroVal / 180.0, np.pi * self.firstVal / 180.0, np.pi * self.secondVal / 180.0)
 
     def setFirstOrder(self, value, *args):
         if self.available:
@@ -3509,7 +3531,7 @@ class PhaseWindow(wc.ToolWindow):
             self.available = False
             self.zeroScale.setValue(int(round(self.zeroVal / 180.0 * self.RESOLUTION)))
             self.available = True
-            self.father.current.setPhaseInter(np.pi * self.zeroVal / 180.0, np.pi * self.firstVal / 180.0)
+            self.father.current.setPhaseInter(np.pi * self.zeroVal / 180.0, np.pi * self.firstVal / 180.0, np.pi * self.secondVal / 180.0)
 
     def inputFirstOrder(self, *args):
         value = safeEval(self.firstEntry.text(), length=self.father.current.len(), Type='FI')
@@ -3524,7 +3546,45 @@ class PhaseWindow(wc.ToolWindow):
         self.zeroScale.setValue(int(round(self.zeroVal / 180.0 * self.RESOLUTION)))
         self.firstScale.setValue(int(round(self.firstVal / self.P1LIMIT * self.RESOLUTION)))
         self.available = True
-        self.father.current.setPhaseInter(np.pi * self.zeroVal / 180.0, np.pi * self.firstVal / 180.0)
+        self.father.current.setPhaseInter(np.pi * self.zeroVal / 180.0, np.pi * self.firstVal / 180.0, np.pi * self.secondVal / 180.0)
+
+    def setSecondOrder(self, value, *args):
+        if self.available:
+            value = float(value) / self.RESOLUTION * self.P2LIMIT
+            pivot = self.pivotVal / self.father.current.sw()
+            newFirst = (self.firstVal - 2 * (value - self.secondVal) * pivot)
+            newZero = (self.zeroVal - (newFirst - self.firstVal) * pivot - (value - self.secondVal) * np.power(pivot, 2))
+            self.zeroVal = np.mod(newZero + 180, 360) - 180
+            self.zeroEntry.setText('%.3f' % self.zeroVal)
+            self.firstVal = newFirst
+            self.firstEntry.setText('%.3f' % newFirst)
+            self.secondVal = value
+            self.secondEntry.setText('%.3f' % self.secondVal)
+            self.available = False
+            self.zeroScale.setValue(int(round(self.zeroVal / 180.0 * self.RESOLUTION)))
+            self.firstScale.setValue(int(round(self.firstVal / self.P1LIMIT * self.RESOLUTION)))
+            self.available = True
+            self.father.current.setPhaseInter(np.pi * self.zeroVal / 180.0, np.pi * self.firstVal / 180.0, np.pi * self.secondVal / 180.0)
+
+    def inputSecondOrder(self, *args):
+        value = safeEval(self.secondEntry.text(), length=self.father.current.len(), Type='FI')
+        if value is None:
+            raise SsnakeException('Phasing: second order value input is not valid!')
+        pivot = self.pivotVal / self.father.current.sw()
+        newFirst = (self.firstVal - 2 * (value - self.secondVal) * pivot)
+        newZero = (self.zeroVal - (newFirst - self.firstVal) * pivot - (value - self.secondVal) * np.power(pivot, 2))
+        self.zeroVal = np.mod(newZero + 180, 360) - 180
+        self.zeroEntry.setText('%.3f' % self.zeroVal)
+        self.firstVal = newFirst
+        self.firstEntry.setText('%.3f' % newFirst)
+        self.secondVal = value
+        self.secondEntry.setText('%.3f' % self.secondVal)
+        self.available = False
+        self.zeroScale.setValue(int(round(self.zeroVal / 180.0 * self.RESOLUTION)))
+        self.firstScale.setValue(int(round(self.firstVal / self.P1LIMIT * self.RESOLUTION)))
+        self.secondScale.setValue(int(round(self.secondVal / self.P2LIMIT * self.RESOLUTION)))
+        self.available = True
+        self.father.current.setPhaseInter(np.pi * self.zeroVal / 180.0, np.pi * self.firstVal / 180.0, np.pi * self.secondVal / 180.0)
 
     def autophase(self, num):
         phases = self.father.current.autoPhase(num)
@@ -3540,7 +3600,7 @@ class PhaseWindow(wc.ToolWindow):
             self.firstEntry.setText('%.3f' % self.firstVal)
         self.inputFirstOrder()
 
-    def stepPhase(self, phase0, phase1):
+    def stepPhase(self, phase0, phase1, phase2):
         step = 1
         multiplier = 1
         if QtWidgets.qApp.keyboardModifiers() & QtCore.Qt.ControlModifier and QtWidgets.qApp.keyboardModifiers() & QtCore.Qt.ShiftModifier:
@@ -3555,6 +3615,7 @@ class PhaseWindow(wc.ToolWindow):
             step = step * multiplier
         phase0 = step * phase0
         phase1 = step * phase1
+        phase2 = step * phase2
         inp = safeEval(self.zeroEntry.text(), length=self.father.current.len(), Type='FI')
         if inp is None:
             raise SsnakeException('Phasing: zero order value input is not valid!')
@@ -3566,17 +3627,25 @@ class PhaseWindow(wc.ToolWindow):
         value += phase1 * self.PHASE1STEP
         if self.father.current.spec() > 0:
             self.inputRef()
-        value += phase1 * self.PHASE1STEP
-        newZero = (self.zeroVal - (value - self.firstVal) * self.pivotVal / self.father.current.sw())
+        second = safeEval(self.secondEntry.text(), length=self.father.current.len(), Type='FI')
+        if second is None:
+            raise SsnakeException('Phasing: second order value input is not valid!')
+        second += phase2 * self.PHASE2STEP
+        pivot = self.pivotVal / self.father.current.sw()
+        newFirst = (value - 2 * (second - self.secondVal) * pivot)
+        newZero = (self.zeroVal - (newFirst - self.firstVal) * pivot - (second - self.secondVal) * np.power(pivot, 2))
         self.zeroVal = np.mod(newZero + 180, 360) - 180
         self.zeroEntry.setText('%.3f' % self.zeroVal)
-        self.firstVal = value
+        self.firstVal = newFirst
         self.firstEntry.setText('%.3f' % self.firstVal)
+        self.secondVal = second
+        self.secondEntry.setText('%.3f' % self.secondVal)
         self.available = False
         self.zeroScale.setValue(round(self.zeroVal / 180.0 * self.RESOLUTION))
         self.firstScale.setValue(round(self.firstVal / self.P1LIMIT * self.RESOLUTION))
+        self.secondScale.setValue(round(self.secondVal / self.P2LIMIT * self.RESOLUTION))
         self.available = True
-        self.father.current.setPhaseInter(np.pi * self.zeroVal / 180.0, np.pi * self.firstVal / 180.0)
+        self.father.current.setPhaseInter(np.pi * self.zeroVal / 180.0, np.pi * self.firstVal / 180.0, np.pi * self.secondVal / 180.0)
 
     def inputRef(self, *args):
         Val = safeEval(self.refEntry.text(), length=self.father.current.len(), Type='FI')
@@ -3598,7 +3667,8 @@ class PhaseWindow(wc.ToolWindow):
             self.inputRef()
         self.inputZeroOrder()
         self.inputFirstOrder()
-        self.father.current.applyPhase(np.pi * self.zeroVal / 180.0, np.pi * self.firstVal / 180.0, (self.singleSlice.isChecked() == 1))
+        self.inputSecondOrder()
+        self.father.current.applyPhase(np.pi * self.zeroVal / 180.0, np.pi * self.firstVal / 180.0, np.pi * self.secondVal / 180.0, (self.singleSlice.isChecked() == 1))
 
 ################################################################
 

--- a/src/views.py
+++ b/src/views.py
@@ -609,7 +609,7 @@ class Current1D(PlotFrame):
         self.upd()
         self.showFid()
 
-    def setPhaseInter(self, phase0in, phase1in):
+    def setPhaseInter(self, phase0in, phase1in, phase2in):
         """
         Interactive changing the phase without editing the actual data.
 
@@ -622,11 +622,12 @@ class Current1D(PlotFrame):
         """
         phase0 = float(phase0in)
         phase1 = float(phase1in)
-        self.data1D.phase(phase0, phase1, -1)
+        phase2 = float(phase2in)
+        self.data1D.phase(phase0, phase1, phase2, -1)
         self.showFid()
         self.upd()
 
-    def applyPhase(self, phase0, phase1, select=False):
+    def applyPhase(self, phase0, phase1, phase2=0, select=False):
         """
         Phase the data.
 
@@ -641,12 +642,13 @@ class Current1D(PlotFrame):
         """
         phase0 = float(phase0)
         phase1 = float(phase1)
+        phase2 = float(phase2)
         if select:
             selectSlice = self.getSelect()
         else:
             selectSlice = slice(None)
-        self.root.addMacro(['phase', (phase0, phase1, self.axes[-1] - self.data.ndim(), selectSlice)])
-        self.data.phase(phase0, phase1, self.axes[-1], selectSlice)
+        self.root.addMacro(['phase', (phase0, phase1, phase2, self.axes[-1] - self.data.ndim(), selectSlice)])
+        self.data.phase(phase0, phase1, phase2, self.axes[-1], selectSlice)
         self.upd()
         self.showFid()
 


### PR DESCRIPTION
There currently is no software available to interactively correct spectra with a 2nd order phase.
I implemented this functionality and made it optional to display, since it is a niche application and could potentially distract new users.

The addition of this feature is important for anyone utilizing frequency swept pulses, namely WURST pulses, because these impose a 2nd order phase on the signal. This is normally dealt with by magnitude processing the spectra, at the expense of a loss of S/N. Being able to correctly phase these spectra interactively should be a nice addition to the general workflow.